### PR TITLE
Fix frontend build by adding placeholder components

### DIFF
--- a/frontend/src/components/admin/BloodCompatibilityFormModal.jsx
+++ b/frontend/src/components/admin/BloodCompatibilityFormModal.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Modal from '../common/Modal';
+import InputField from '../common/InputField';
+import Button from '../common/Button';
+
+const BloodCompatibilityFormModal = ({ open, onClose }) => (
+  <Modal open={open} onClose={onClose} title="Compatibility Rule">
+    <div className="space-y-4">
+      <InputField label="Blood Type" id="bloodType" />
+      <InputField label="Compatible With" id="compatible" />
+      <Button onClick={onClose}>Save</Button>
+    </div>
+  </Modal>
+);
+
+export default BloodCompatibilityFormModal;

--- a/frontend/src/components/admin/BloodTypeFormModal.jsx
+++ b/frontend/src/components/admin/BloodTypeFormModal.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Modal from '../common/Modal';
+import InputField from '../common/InputField';
+import Button from '../common/Button';
+
+const BloodTypeFormModal = ({ open, onClose }) => (
+  <Modal open={open} onClose={onClose} title="Blood Type">
+    <div className="space-y-4">
+      <InputField label="Blood Type" id="bloodType" />
+      <Button onClick={onClose}>Save</Button>
+    </div>
+  </Modal>
+);
+
+export default BloodTypeFormModal;

--- a/frontend/src/components/admin/CriticalAlertsWidget.jsx
+++ b/frontend/src/components/admin/CriticalAlertsWidget.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const CriticalAlertsWidget = () => (
+  <div className="p-4 bg-white rounded shadow">Critical alerts</div>
+);
+
+export default CriticalAlertsWidget;

--- a/frontend/src/components/admin/DashboardStatCard.jsx
+++ b/frontend/src/components/admin/DashboardStatCard.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const DashboardStatCard = ({ title, value }) => (
+  <div className="p-4 bg-white rounded shadow">
+    <h4 className="text-sm text-gray-500">{title}</h4>
+    <p className="text-xl font-bold">{value}</p>
+  </div>
+);
+
+export default DashboardStatCard;

--- a/frontend/src/components/admin/UserManagementTable.jsx
+++ b/frontend/src/components/admin/UserManagementTable.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+const UserManagementTable = ({ users = [] }) => (
+  <table className="w-full border">
+    <thead>
+      <tr className="bg-gray-100">
+        <th className="p-2 text-left">Name</th>
+        <th className="p-2 text-left">Email</th>
+      </tr>
+    </thead>
+    <tbody>
+      {users.map(u => (
+        <tr key={u.id} className="border-t">
+          <td className="p-2">{u.fullName}</td>
+          <td className="p-2">{u.email}</td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+);
+
+export default UserManagementTable;

--- a/frontend/src/components/auth/ProtectedRoute.jsx
+++ b/frontend/src/components/auth/ProtectedRoute.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '../../hooks/useAuth';
+
+const ProtectedRoute = ({ requireAuth = true, requiredRoles, children }) => {
+  const { isAuthenticated, user } = useAuth();
+
+  if (requireAuth && !isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (requiredRoles && !requiredRoles.includes(user?.role)) {
+    return <Navigate to="/forbidden" replace />;
+  }
+
+  return children ? children : <Outlet />;
+};
+
+export default ProtectedRoute;

--- a/frontend/src/components/blog/BlogPostCard.jsx
+++ b/frontend/src/components/blog/BlogPostCard.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const BlogPostCard = ({ post }) => (
+  <article className="border rounded p-4">
+    <h3 className="font-bold text-lg">
+      <Link to={`/blog/${post.slug}`}>{post.title}</Link>
+    </h3>
+    <p className="text-sm text-gray-600">{post.excerpt}</p>
+  </article>
+);
+
+export default BlogPostCard;

--- a/frontend/src/components/common/Button.jsx
+++ b/frontend/src/components/common/Button.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Button = ({ className = '', children, ...props }) => (
+  <button
+    className={`px-4 py-2 rounded bg-red-600 text-white disabled:opacity-50 ${className}`}
+    {...props}
+  >
+    {children}
+  </button>
+);
+
+export default Button;

--- a/frontend/src/components/common/ErrorBoundary.jsx
+++ b/frontend/src/components/common/ErrorBoundary.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <p className="p-4 text-red-600">Something went wrong.</p>;
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/components/common/InputField.jsx
+++ b/frontend/src/components/common/InputField.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const InputField = ({ label, id, type = 'text', className = '', ...props }) => (
+  <div className="space-y-1">
+    {label && (
+      <label htmlFor={id} className="block text-sm font-medium text-gray-700">
+        {label}
+      </label>
+    )}
+    <input
+      id={id}
+      type={type}
+      className={`w-full border rounded p-2 ${className}`}
+      {...props}
+    />
+  </div>
+);
+
+export default InputField;

--- a/frontend/src/components/common/LoadingSpinner.jsx
+++ b/frontend/src/components/common/LoadingSpinner.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const LoadingSpinner = ({ className = '' }) => (
+  <div className={`animate-spin h-5 w-5 border-4 border-gray-300 border-t-red-600 rounded-full ${className}`} />
+);
+
+export default LoadingSpinner;

--- a/frontend/src/components/common/Modal.jsx
+++ b/frontend/src/components/common/Modal.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const Modal = ({ open, onClose, title, children }) => {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+      <div className="bg-white rounded p-4 w-full max-w-lg">
+        <div className="flex justify-between items-center mb-2">
+          <h2 className="font-bold text-lg">{title}</h2>
+          <button onClick={onClose}>×</button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/frontend/src/components/common/Pagination.jsx
+++ b/frontend/src/components/common/Pagination.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const Pagination = ({ page, totalPages, onPageChange }) => {
+  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+  return (
+    <nav className="flex gap-2">
+      {pages.map(p => (
+        <button
+          key={p}
+          onClick={() => onPageChange(p)}
+          className={`px-3 py-1 rounded ${p === page ? 'bg-red-600 text-white' : 'bg-gray-200'}`}
+        >
+          {p}
+        </button>
+      ))}
+    </nav>
+  );
+};
+
+export default Pagination;

--- a/frontend/src/components/common/SEO.jsx
+++ b/frontend/src/components/common/SEO.jsx
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+
+const SEO = ({ title, description }) => {
+  useEffect(() => {
+    if (title) document.title = title;
+  }, [title]);
+
+  return null;
+};
+
+export default SEO;

--- a/frontend/src/components/common/SearchBar.jsx
+++ b/frontend/src/components/common/SearchBar.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const SearchBar = ({ value, onChange, placeholder = 'Search...' }) => (
+  <input
+    type="text"
+    value={value}
+    onChange={e => onChange(e.target.value)}
+    placeholder={placeholder}
+    className="border rounded px-3 py-2 w-full"
+  />
+);
+
+export default SearchBar;

--- a/frontend/src/components/dashboard/DashboardAppointments.jsx
+++ b/frontend/src/components/dashboard/DashboardAppointments.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const DashboardAppointments = () => (
+  <div className="p-4 bg-white rounded shadow">Appointments</div>
+);
+
+export default DashboardAppointments;

--- a/frontend/src/components/dashboard/DashboardEmergencyRequests.jsx
+++ b/frontend/src/components/dashboard/DashboardEmergencyRequests.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const DashboardEmergencyRequests = () => (
+  <div className="p-4 bg-white rounded shadow">Emergency requests</div>
+);
+
+export default DashboardEmergencyRequests;

--- a/frontend/src/components/dashboard/DashboardOverview.jsx
+++ b/frontend/src/components/dashboard/DashboardOverview.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const DashboardOverview = () => (
+  <div className="p-4 bg-white rounded shadow">Dashboard overview content</div>
+);
+
+export default DashboardOverview;

--- a/frontend/src/components/forms/Input.jsx
+++ b/frontend/src/components/forms/Input.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const Input = ({ label, id, type = 'text', className = '', ...props }) => (
+  <div className="space-y-1">
+    {label && <label htmlFor={id} className="block text-sm font-medium">{label}</label>}
+    <input id={id} type={type} className={`border rounded p-2 w-full ${className}`} {...props} />
+  </div>
+);
+
+export default Input;

--- a/frontend/src/components/forms/Select.jsx
+++ b/frontend/src/components/forms/Select.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Select = ({ label, id, className = '', children, ...props }) => (
+  <div className="space-y-1">
+    {label && <label htmlFor={id} className="block text-sm font-medium">{label}</label>}
+    <select id={id} className={`border rounded p-2 w-full ${className}`} {...props}>
+      {children}
+    </select>
+  </div>
+);
+
+export default Select;

--- a/frontend/src/components/forms/Textarea.jsx
+++ b/frontend/src/components/forms/Textarea.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const Textarea = ({ label, id, className = '', ...props }) => (
+  <div className="space-y-1">
+    {label && <label htmlFor={id} className="block text-sm font-medium">{label}</label>}
+    <textarea id={id} className={`border rounded p-2 w-full ${className}`} {...props} />
+  </div>
+);
+
+export default Textarea;

--- a/frontend/src/components/home/CTASection.jsx
+++ b/frontend/src/components/home/CTASection.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Button from '../common/Button';
+import { Link } from 'react-router-dom';
+
+const CTASection = () => (
+  <section className="py-12 text-center">
+    <h2 className="text-2xl font-bold mb-4">Ready to donate?</h2>
+    <Button as={Link} to="/request-donation">Request Now</Button>
+  </section>
+);
+
+export default CTASection;

--- a/frontend/src/components/home/FeaturesSection.jsx
+++ b/frontend/src/components/home/FeaturesSection.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const FeaturesSection = () => (
+  <section className="py-12">
+    <h2 className="text-2xl font-bold mb-4 text-center">Features</h2>
+    <ul className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <li className="p-4 bg-white rounded shadow">Easy to register</li>
+      <li className="p-4 bg-white rounded shadow">Find nearby donations</li>
+      <li className="p-4 bg-white rounded shadow">Track your history</li>
+    </ul>
+  </section>
+);
+
+export default FeaturesSection;

--- a/frontend/src/components/home/HeroSection.jsx
+++ b/frontend/src/components/home/HeroSection.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Button from '../common/Button';
+import { Link } from 'react-router-dom';
+
+const HeroSection = () => (
+  <section className="text-center py-20 bg-red-600 text-white">
+    <h1 className="text-4xl font-bold mb-4">Welcome to BloodConnect</h1>
+    <p className="mb-6">Join us to save lives through blood donation.</p>
+    <Button as={Link} to="/register">Get Started</Button>
+  </section>
+);
+
+export default HeroSection;

--- a/frontend/src/components/home/StatsSection.jsx
+++ b/frontend/src/components/home/StatsSection.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const StatsSection = () => (
+  <section className="py-12 bg-gray-50 text-center">
+    <h2 className="text-2xl font-bold mb-4">Our Impact</h2>
+    <div className="flex justify-center space-x-8">
+      <div>
+        <p className="text-3xl font-bold">1000+</p>
+        <p>Donors</p>
+      </div>
+      <div>
+        <p className="text-3xl font-bold">500+</p>
+        <p>Requests</p>
+      </div>
+    </div>
+  </section>
+);
+
+export default StatsSection;

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -1,0 +1,6 @@
+export { default as Button } from './common/Button.jsx';
+export { default as Input } from './forms/Input.jsx';
+export { default as Select } from './forms/Select.jsx';
+export { default as Container } from './ui/Container.jsx';
+export { default as SEO } from './common/SEO.jsx';
+export { default as ToastProvider } from './ui/Toast.jsx';

--- a/frontend/src/components/layouts/AdminLayout.jsx
+++ b/frontend/src/components/layouts/AdminLayout.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Outlet, Link } from 'react-router-dom';
+
+const AdminLayout = () => (
+  <div className="flex min-h-screen">
+    <aside className="w-64 bg-gray-200 p-4 space-y-2">
+      <h2 className="font-bold text-lg">Admin</h2>
+      <nav className="space-y-1">
+        <Link to="/admin" className="block">Dashboard</Link>
+        <Link to="/admin/users" className="block">Users</Link>
+      </nav>
+    </aside>
+    <main className="flex-1 p-4">
+      <Outlet />
+    </main>
+  </div>
+);
+
+export default AdminLayout;

--- a/frontend/src/components/layouts/Footer.jsx
+++ b/frontend/src/components/layouts/Footer.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Footer = () => (
+  <footer className="bg-gray-100 text-center py-4 mt-auto">
+    <p className="text-sm text-gray-500">&copy; {new Date().getFullYear()} BloodConnect</p>
+  </footer>
+);
+
+export default Footer;

--- a/frontend/src/components/layouts/MainLayout.jsx
+++ b/frontend/src/components/layouts/MainLayout.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import Navbar from './Navbar';
+import Footer from './Footer';
+
+const MainLayout = () => (
+  <div className="flex flex-col min-h-screen">
+    <Navbar />
+    <main className="flex-1 p-4">
+      <Outlet />
+    </main>
+    <Footer />
+  </div>
+);
+
+export default MainLayout;

--- a/frontend/src/components/layouts/Navbar.jsx
+++ b/frontend/src/components/layouts/Navbar.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const Navbar = () => (
+  <nav className="bg-red-600 text-white px-4 py-2 flex justify-between">
+    <Link to="/" className="font-bold">BloodConnect</Link>
+    <div className="space-x-4">
+      <Link to="/login" className="hover:underline">Login</Link>
+      <Link to="/register" className="hover:underline">Register</Link>
+    </div>
+  </nav>
+);
+
+export default Navbar;

--- a/frontend/src/components/layouts/PageHeader.jsx
+++ b/frontend/src/components/layouts/PageHeader.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const PageHeader = ({ title }) => (
+  <header className="mb-4 border-b pb-2">
+    <h1 className="text-2xl font-bold">{title}</h1>
+  </header>
+);
+
+export default PageHeader;

--- a/frontend/src/components/ui/Badge.jsx
+++ b/frontend/src/components/ui/Badge.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const Badge = ({ children, className = '' }) => (
+  <span className={`inline-block px-2 py-1 text-xs rounded bg-red-100 text-red-700 ${className}`}>{children}</span>
+);
+
+export default Badge;

--- a/frontend/src/components/ui/Card.jsx
+++ b/frontend/src/components/ui/Card.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export const Card = ({ children, className = '' }) => (
+  <div className={`bg-white shadow rounded p-4 ${className}`}>{children}</div>
+);
+
+export const CardHeader = ({ children, className = '' }) => (
+  <div className={`mb-2 font-bold text-lg ${className}`}>{children}</div>
+);
+
+export const CardContent = ({ children, className = '' }) => (
+  <div className={className}>{children}</div>
+);
+
+export const CardTitle = ({ children, className = '' }) => (
+  <h3 className={`text-xl font-semibold ${className}`}>{children}</h3>
+);

--- a/frontend/src/components/ui/Container.jsx
+++ b/frontend/src/components/ui/Container.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Container = ({ children, className = '' }) => (
+  <div className={`max-w-5xl mx-auto px-4 ${className}`}>{children}</div>
+);
+
+export default Container;

--- a/frontend/src/components/ui/Toast.jsx
+++ b/frontend/src/components/ui/Toast.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Toaster } from 'react-hot-toast';
+
+export const ToastProvider = ({ children }) => (
+  <>
+    {children}
+    <Toaster position="top-right" />
+  </>
+);
+
+export default ToastProvider;

--- a/frontend/src/components/user/AccountTab.jsx
+++ b/frontend/src/components/user/AccountTab.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Button from '../common/Button';
+
+const AccountTab = () => (
+  <div className="space-y-4">
+    <p>Manage account settings here.</p>
+    <Button>Change Password</Button>
+  </div>
+);
+
+export default AccountTab;

--- a/frontend/src/components/user/DonationGuideSidebar.jsx
+++ b/frontend/src/components/user/DonationGuideSidebar.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const DonationGuideSidebar = () => (
+  <aside className="bg-white p-4 rounded shadow">
+    <h3 className="font-bold mb-2">Donation Guide</h3>
+    <ul className="list-disc list-inside text-sm text-gray-700 space-y-1">
+      <li>Eat well before donating.</li>
+      <li>Bring ID documents.</li>
+      <li>Stay hydrated.</li>
+    </ul>
+  </aside>
+);
+
+export default DonationGuideSidebar;

--- a/frontend/src/components/user/DonationHistoryList.jsx
+++ b/frontend/src/components/user/DonationHistoryList.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const DonationHistoryList = ({ donations = [] }) => (
+  <ul className="space-y-2">
+    {donations.length === 0 && <li>No donations yet.</li>}
+    {donations.map((d, idx) => (
+      <li key={idx} className="border p-2 rounded">
+        {d}
+      </li>
+    ))}
+  </ul>
+);
+
+export default DonationHistoryList;

--- a/frontend/src/components/user/ProfileTab.jsx
+++ b/frontend/src/components/user/ProfileTab.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Input from '../forms/Input';
+import Button from '../common/Button';
+
+const ProfileTab = ({ userProfile, onProfileUpdate }) => {
+  const handleSubmit = e => {
+    e.preventDefault();
+    onProfileUpdate && onProfileUpdate(userProfile);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <Input label="Full Name" id="fullName" value={userProfile.fullName} readOnly />
+      <Input label="Email" id="email" type="email" value={userProfile.email} readOnly />
+      <Button type="submit">Update</Button>
+    </form>
+  );
+};
+
+export default ProfileTab;

--- a/frontend/src/components/user/UserProfileSidebar.jsx
+++ b/frontend/src/components/user/UserProfileSidebar.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const UserProfileSidebar = ({ user }) => (
+  <div className="bg-white p-4 rounded shadow">
+    <h2 className="font-bold text-lg mb-2">{user.fullName}</h2>
+    <p className="text-sm text-gray-600">{user.email}</p>
+  </div>
+);
+
+export default UserProfileSidebar;

--- a/frontend/src/pages/BlogDetailPage.jsx
+++ b/frontend/src/pages/BlogDetailPage.jsx
@@ -4,7 +4,7 @@ import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft, Calendar, User, Clock } from 'lucide-react';
 import blogService from '../services/blogService';
 // import { mockBlogPosts } from '../mocks/handlers/blogHandlers';
-import NotFoundPage from './NotFoundPage';
+import NotFoundPage from './NotfoundPage';
 
 const BlogDetailPage = () => {
     const { slug } = useParams();

--- a/frontend/src/routes/AppRoutes.jsx
+++ b/frontend/src/routes/AppRoutes.jsx
@@ -24,10 +24,6 @@ import AdminDonationHistoryPage from "../pages/admin/AdminDonationHistoryPage";
 import AdminEmergencyRequestsPage from "../pages/admin/AdminEmergencyRequestsPage";
 import AdminBloodInventoryPage from "../pages/admin/AdminBloodInventoryPage";
 
-import StaffDashboardPage from "../pages/staff/StaffDashboardPage"; 
-import StaffDonorManagementPage from "../pages/staff/StaffDonorManagementPage"; 
-import StaffInventoryPage from "../pages/staff/StaffInventoryPage"; 
-import StaffDonationRequestsPage from "../pages/staff/StaffDonationRequestsPage"; 
 
 
 import MemberDashboardPage from "../pages/MemberDashboardPage";
@@ -77,15 +73,6 @@ const AppRoutes = () => (
             </Route>
         </Route>
 
-        {/* Staff Routes */}
-        <Route element={<ProtectedRoute requiredRoles={['Staff', 'Admin']} />}>
-            <Route path="/staff" element={<AdminLayout />}>
-                <Route index element={<StaffDashboardPage />} />
-                <Route path="donors" element={<StaffDonorManagementPage />} />
-                <Route path="inventory" element={<StaffInventoryPage />} />
-                <Route path="requests" element={<StaffDonationRequestsPage />} />
-            </Route>
-        </Route>
 
         {/* Not Found Route */}
         <Route path="*" element={<NotFoundPage />} />


### PR DESCRIPTION
## Summary
- restore basic component structure so the frontend can build
- implement simple layout components (navbar, footer, layouts)
- add common UI helpers (buttons, inputs, modal, etc.)
- stub user and admin components used across pages
- fix blog detail import case typo
- remove missing staff routes

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6854c1d6fa6c832f82b33aa9834acbbf